### PR TITLE
Add link checker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ md-tree stats README.md
 md-tree toc README.md --max-level 3
 ```
 
+### Check links
+
+```bash
+md-tree check-links README.md
+md-tree check-links README.md --recursive
+```
+
 ### Complete CLI options
 
 ```bash
@@ -144,13 +151,17 @@ console.log(sectionMarkdown);
 ### Advanced Usage
 
 ```javascript
-import { MarkdownTreeParser, createParser, extractSection } from 'markdown-tree-parser';
+import {
+  MarkdownTreeParser,
+  createParser,
+  extractSection,
+} from 'markdown-tree-parser';
 
 // Create parser with custom options
 const parser = createParser({
-  bullet: '-',      // Use '-' for lists
-  emphasis: '_',    // Use '_' for emphasis
-  strong: '__'      // Use '__' for strong
+  bullet: '-', // Use '-' for lists
+  emphasis: '_', // Use '_' for emphasis
+  strong: '__', // Use '__' for strong
 });
 
 // Extract all sections at level 2
@@ -178,8 +189,7 @@ const codeBlocks = parser.selectAll(tree, 'code');
 
 // Custom search
 const customNode = parser.findNode(tree, (node) => {
-  return node.type === 'heading' &&
-         parser.getHeadingText(node).includes('API');
+  return node.type === 'heading' && parser.getHeadingText(node).includes('API');
 });
 
 // Transform content
@@ -191,7 +201,9 @@ parser.transform(tree, (node) => {
 
 // Get document statistics
 const stats = parser.getStats(tree);
-console.log(`Document has ${stats.wordCount} words and ${stats.headings.total} headings`);
+console.log(
+  `Document has ${stats.wordCount} words and ${stats.headings.total} headings`
+);
 
 // Generate table of contents
 const toc = parser.generateTableOfContents(tree, 3);
@@ -234,7 +246,7 @@ for (let i = 0; i < sections.length; i++) {
 #### Constructor
 
 ```javascript
-new MarkdownTreeParser(options = {})
+new MarkdownTreeParser((options = {}));
 ```
 
 #### Methods
@@ -265,18 +277,18 @@ The library supports powerful CSS-like selectors for searching:
 
 ```javascript
 // Element selectors
-parser.selectAll(tree, 'heading')     // All headings
-parser.selectAll(tree, 'paragraph')  // All paragraphs
-parser.selectAll(tree, 'link')       // All links
+parser.selectAll(tree, 'heading'); // All headings
+parser.selectAll(tree, 'paragraph'); // All paragraphs
+parser.selectAll(tree, 'link'); // All links
 
 // Attribute selectors
-parser.selectAll(tree, 'heading[depth=1]')    // H1 headings
-parser.selectAll(tree, 'heading[depth=2]')    // H2 headings
-parser.selectAll(tree, 'link[url*="github"]') // Links containing "github"
+parser.selectAll(tree, 'heading[depth=1]'); // H1 headings
+parser.selectAll(tree, 'heading[depth=2]'); // H2 headings
+parser.selectAll(tree, 'link[url*="github"]'); // Links containing "github"
 
 // Pseudo selectors
-parser.selectAll(tree, ':first-child')  // First child elements
-parser.selectAll(tree, ':last-child')   // Last child elements
+parser.selectAll(tree, ':first-child'); // First child elements
+parser.selectAll(tree, ':last-child'); // Last child elements
 ```
 
 ## 🧪 Testing

--- a/index.js
+++ b/index.js
@@ -75,3 +75,15 @@ export async function generateTOC(markdown, maxLevel = 3, options = {}) {
   const tree = await parser.parse(markdown);
   return parser.generateTableOfContents(tree, maxLevel);
 }
+
+/**
+ * Quick utility to check links in markdown
+ * @param {string} markdown - Markdown content
+ * @param {Object} options - Parser options
+ * @returns {Promise<Array>} Array of link check results
+ */
+export async function checkLinks(markdown, options = {}) {
+  const parser = new MarkdownTreeParser(options);
+  const tree = await parser.parse(markdown);
+  return parser.checkLinks(tree, options);
+}

--- a/lib/markdown-parser.js
+++ b/lib/markdown-parser.js
@@ -399,4 +399,63 @@ export class MarkdownTreeParser {
 
     return toc;
   }
+
+  /**
+   * Check that all links in a document are reachable
+   * @param {Object} tree - Parsed markdown AST
+   * @param {Object} options - Options object
+   * @param {string} [options.baseDir='.'] - Base directory for resolving local links
+   * @param {boolean} [options.recursive=false] - Recursively check linked markdown files
+   * @param {Set<string>} [options._visited] - Internal set of visited files to prevent loops
+   * @returns {Promise<Array>} Array of result objects { url, ok, status?, error? }
+   */
+  async checkLinks(
+    tree,
+    { baseDir = '.', recursive = false, _visited = new Set() } = {}
+  ) {
+    const links = [];
+    visit(tree, 'link', (node) => {
+      if (node.url) links.push(node.url);
+    });
+
+    const results = [];
+
+    for (const url of links) {
+      if (url.startsWith('http://') || url.startsWith('https://')) {
+        try {
+          const res = await fetch(url, { method: 'HEAD' });
+          results.push({ url, ok: res.ok, status: res.status });
+        } catch (err) {
+          results.push({ url, ok: false, error: err.message });
+        }
+      } else if (url.startsWith('#') || url.startsWith('mailto:')) {
+        // Assume local anchors and mailto links are valid
+        results.push({ url, ok: true });
+      } else {
+        const target = path.resolve(baseDir, url.split('#')[0]);
+        try {
+          await fs.access(target);
+          results.push({ url, ok: true });
+
+          if (recursive && /\.md$/i.test(target)) {
+            if (!_visited.has(target)) {
+              _visited.add(target);
+              const content = await fs.readFile(target, 'utf-8');
+              const subTree = await this.parse(content);
+              const subResults = await this.checkLinks(subTree, {
+                baseDir: path.dirname(target),
+                recursive,
+                _visited,
+              });
+              results.push(...subResults);
+            }
+          }
+        } catch (err) {
+          results.push({ url, ok: false, error: 'File not found' });
+        }
+      }
+    }
+
+    return results;
+  }
 }


### PR DESCRIPTION
## Summary
- add `checkLinks` utility to markdown parser
- expose `checkLinks` from package entry
- support `check-links` command in CLI with `--recursive`
- document link checking in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package 'unified')*
- `npm run test:cli` *(fails: Cannot find package 'unified')*

------
https://chatgpt.com/codex/tasks/task_e_684bb1668c608326bb6cbf9bc501e3b9