### PR TITLE
CJK Support Added for Markdown Slug Generation

### DIFF
--- a/bin/md-tree.js
+++ b/bin/md-tree.js
@@ -107,7 +107,10 @@ class MarkdownCLI {
   sanitizeText(text) {
     return text
       .toLowerCase()
-      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(
+        /[^a-z0-9\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\s-]/g,
+        ''
+      )
       .replace(/\s+/g, '-')
       .replace(/-+/g, '-')
       .replace(/^-|-$/g, '');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kayvan/markdown-tree-parser",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "A powerful JavaScript library and CLI tool for parsing and manipulating markdown files as tree structures using the remark/unified ecosystem",
   "type": "module",
   "main": "index.js",

--- a/test/test-cjk.md
+++ b/test/test-cjk.md
@@ -1,0 +1,17 @@
+# Document Title
+
+## 章节一
+
+This is the first section.
+
+## 章二
+
+This is the second section.
+
+### セクション 2.1
+
+This is a subsection.
+
+## Another Section
+
+This is another section.

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -445,6 +445,42 @@ This document has links too:
     );
   });
 
+  await test('CLI explode command with CJK characters', async () => {
+    const cjkTestFile = path.resolve(__dirname, 'test-cjk.md');
+    const outputDir = path.join(testDir, 'cjk-exploded');
+    const result = await runCLI(['explode', cjkTestFile, outputDir]);
+
+    assert(
+      result.code === 0,
+      `Command should succeed, got exit code ${result.code}\nstderr: ${result.stderr}`
+    );
+
+    const files = await fs.readdir(outputDir);
+    assert(files.includes('index.md'), 'Should create index.md');
+    assert(files.includes('章节一.md'), 'Should create file with Chinese slug');
+    assert(files.includes('章二.md'), 'Should create file with Chinese slug');
+    assert(
+      files.includes('another-section.md'),
+      'Should create file with English slug'
+    );
+
+    // Check the index file for correct links
+    const indexPath = path.join(outputDir, 'index.md');
+    const indexContent = await fs.readFile(indexPath, 'utf-8');
+    assert(
+      indexContent.includes('[章节一](./章节一.md)'),
+      'Should link to Chinese filename'
+    );
+    assert(
+      indexContent.includes('[章二](./章二.md)'),
+      'Should link to Chinese filename'
+    );
+    assert(
+      indexContent.includes('[セクション 2.1](./章二.md#セクション-21)'),
+      'Should link to Japanese subsection'
+    );
+  });
+
   await cleanupTests();
 
   // Summary


### PR DESCRIPTION
# CJK Support Added for Markdown Slug Generation

## Summary

This PR adds support for CJK (Chinese, Japanese, Korean) characters in the markdown file slug generation, allowing non-Latin characters to be preserved in generated filenames and anchors when using the `explode` command.

## Related Isssues

Closes #5 

## Files Changed

### `bin/md-tree.js`
Modified the `sanitizeText` method to preserve CJK characters instead of stripping them out. The regex now includes Unicode ranges for Chinese, Japanese (Hiragana and Katakana), and Korean characters.

### `package.json`
Bumped the version from 1.5.1 to 1.6.0 to reflect the new feature addition.

### `test/test-cjk.md`
Added a new test markdown file containing CJK characters in headings to verify the functionality works correctly.

### `test/test-cli.js`
Added a comprehensive test case to verify that the `explode` command correctly handles CJK characters in headings, generates appropriate filenames, and creates proper links.

## Code Changes

### `bin/md-tree.js`
```javascript
// Before
.replace(/[^a-z0-9\s-]/g, '')

// After
.replace(
  /[^a-z0-9\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\s-]/g,
  ''
)
```
The regex now includes Unicode ranges:
- `\u4e00-\u9fff`: Chinese characters
- `\u3040-\u309f`: Japanese Hiragana
- `\u30a0-\u30ff`: Japanese Katakana
- `\uac00-\ud7af`: Korean Hangul

### `test/test-cli.js`
```javascript
await test('CLI explode command with CJK characters', async () => {
  // Test verifies:
  // 1. Files are created with CJK characters in filenames
  // 2. Index file contains correct links to CJK-named files
  // 3. Subsection anchors with CJK characters work correctly
});
```

## Reason for Changes

Previously, the markdown tree parser would strip out all non-Latin characters when generating slugs for filenames and anchors. This made the tool unsuitable for documentation written in CJK languages, as headings like "章节一" would be converted to empty strings or hyphens only, resulting in non-descriptive or conflicting filenames.

## Impact of Changes

1. **Internationalization**: The tool now supports markdown documents written in Chinese, Japanese, and Korean, making it accessible to a much wider user base.
2. **Backward Compatibility**: Existing functionality for Latin-based text remains unchanged. The change is additive and non-breaking.
3. **File Naming**: Generated filenames will now preserve CJK characters, making them more meaningful and readable for users working with these languages.

## Test Plan

A comprehensive test case has been added that:
1. Creates a test markdown file with CJK headings
2. Runs the `explode` command on this file
3. Verifies that files are created with CJK characters in their names
4. Checks that the generated index file contains correct links to these files
5. Ensures subsection anchors with CJK characters are properly formatted

The test covers Chinese characters in main headings and Japanese characters in subsections, alongside regular English headings to ensure mixed-language documents work correctly.

## Additional Notes

- The Unicode ranges included cover the most common CJK character sets but may not include all possible characters (e.g., CJK Extension blocks). Additional ranges can be added if needed.
- The version bump to 1.6.0 indicates this is a minor feature addition with no breaking changes.
- This change aligns with modern web standards where URLs and filenames increasingly support Unicode characters.
